### PR TITLE
Follow HTTP redirections to HTTPS server

### DIFF
--- a/app/src/main/java/org/traccar/manager/StartFragment.java
+++ b/app/src/main/java/org/traccar/manager/StartFragment.java
@@ -69,6 +69,16 @@ public class StartFragment extends Fragment implements View.OnClickListener {
                     Uri uri = Uri.parse(urls[0]).buildUpon().appendEncodedPath("api/server").build();
                     URL url = new URL(uri.toString());
                     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+                    int responseCode = urlConnection.getResponseCode();
+                    switch(responseCode) {
+                    case HttpURLConnection.HTTP_MOVED_TEMP:
+                    case HttpURLConnection.HTTP_MOVED_PERM:
+                        String location = urlConnection.getHeaderField("Location");
+                        if(location != null) {
+                            url = new URL(location);
+                            urlConnection = (HttpURLConnection) url.openConnection();
+                        }
+                    }
                     BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 
                     String line;


### PR DESCRIPTION
When Traccar is relocated to HTTPS listener, URL should be followed
within the code to reach new location.