### PR TITLE
Accept custom installed CA

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true" />
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
At the moment the latest Android releases do not accept manually installed private CAs without the proposed change. This change allows for using private CAs instead of using commercial providers or Lets Encrypt.

Using a privately owned CA is a lot safer than not using SSL at all which is now possible.

An important downside of using a Lets Encrypt is that your certificate and domain is published in the certificate transparency logs and your server can be more easily found.

Fixes #20 #55 #79 and many issues from the forum